### PR TITLE
fix: build-linux:gh 잘 안되는 현상 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix \"./src/**/*.{ts,tsx,js,jsx}\"",
     "eject": "react-scripts eject",
     "build-win:gh": "set \"PUBLIC_URL=/FanFixiv-user-page\" && craco build && copy build\\fonts\\index.css.gh-page build\\fonts\\index.css",
-    "build-linux:gh": "PUBLIC_URL=/FanFixiv-user-page && craco build && cp build/fonts/index.css.gh-page build/fonts/index.css",
+    "build-linux:gh": "export PUBLIC_URL=/FanFixiv-user-page && craco build && cp build/fonts/index.css.gh-page build/fonts/index.css",
     "deploy:gh": "gh-pages -d build"
   },
   "eslintConfig": {


### PR DESCRIPTION
> #25

**PR 설명**
CRA는 public url을 세팅할 때 webpack이 아닌 환경변수에 설정합니다.
리눅스에서는 export <path-name> = <path>로 해야 동작하는 거 같습니다. package.json에서 PUBLIC_URL=/FanFixiv-user-page를 export PUBLIC_URL=/FanFixiv-user-page로 바꿔줬습니다.

**개발된 기능**
- build-linux:gh 수정

**레퍼런스**
- https://stackoverflow.com/questions/42686149/cant-build-create-react-app-project-with-custom-public-url
