### PR TITLE
gh-pages 404 문제

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint \"./src/**/*.{ts,tsx,js,jsx}\"",
     "lint:fix": "eslint --fix \"./src/**/*.{ts,tsx,js,jsx}\"",
     "eject": "react-scripts eject",
-    "build-win:gh": "set \"PUBLIC_URL=/FanFixiv-user-page\" && craco build && copy build\\fonts\\index.css.gh-page build\\fonts\\index.css",
-    "build-linux:gh": "PUBLIC_URL=/FanFixiv-user-page && craco build && cp build/fonts/index.css.gh-page build/fonts/index.css",
+    "build-win:gh": "set \"PUBLIC_URL=/FanFixiv-user-page\" && craco build && copy build\\fonts\\index.css.gh-page build\\fonts\\index.css && cp build\\index.html build\\404.html",
+    "build-linux:gh": "PUBLIC_URL=/FanFixiv-user-page && craco build && cp build/fonts/index.css.gh-page build/fonts/index.css && cp build/index.html build/404.html",
     "deploy:gh": "gh-pages -d build"
   },
   "eslintConfig": {


### PR DESCRIPTION
> #29 참고

**PR 설명**
index.html를 404.html로 복사하도록 build:gh를 세팅했습니다.
gh-pages가 404.html을 띄울 때 index.html과 같은 내용을 띄워
react-router가 동작할 수 있습니다.

**개발된 기능**
- gh-pages에서 react-router 사용 가능

**레퍼런스**
- https://velog.io/@heyoon/github-pages%EC%97%90%EC%84%9C-%EB%9D%BC%EC%9A%B0%ED%8C%85%EB%90%9C-%ED%8E%98%EC%9D%B4%EC%A7%80%EC%97%90%EC%84%9C-%EC%83%88%EB%A1%9C%EA%B3%A0%EC%B9%A8%EC%8B%9C-404%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A5%BC-%EB%B0%98%ED%99%98%ED%95%A9%EB%8B%88%EB%8B%A4 <- 블로그 제목: gh-pages에서 404를 반환합니다.
